### PR TITLE
Removed all upper bounds from dependencies.

### DIFF
--- a/openid.cabal
+++ b/openid.cabal
@@ -1,5 +1,5 @@
 name:               openid
-version:            0.2.0.0
+version:            0.2.0.1
 cabal-version:      >= 1.8
 synopsis:           An implementation of the OpenID-2.0 spec.
 description:        An implementation of the OpenID-2.0 spec.


### PR DESCRIPTION
This is related to issue #5. With this patch it is possible to build this with Ubuntu provided libraries, requiring only HsOpenSSL and monadLib to be installed via Cabal. This is good news for avoiding "diamond dependencies". I haven't done any testing yet (it compiles, though), so this pull request is just to give you the idea. :-)
