### PR TITLE
Use unsafePerformIO from System.IO.Unsafe for GHC 7.8 compatibility

### DIFF
--- a/src/Data/Digest/OpenSSL/SHA.hs
+++ b/src/Data/Digest/OpenSSL/SHA.hs
@@ -16,6 +16,7 @@ module Data.Digest.OpenSSL.SHA (sha1, sha256) where
 import Control.Exception
 import Foreign
 import Foreign.C
+import System.IO.Unsafe (unsafePerformIO)
 
 data EVP_MD
 data EVP_MD_CTX


### PR DESCRIPTION
Deprecated `unsafePerformIO` export from `Foreign` is removed in base-4.7.0.0.
